### PR TITLE
fix bundle file

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7,7 +7,7 @@
   <script src="https://identity-js.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@^2.0/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^2.0/dist/netlify-cms.js"></script>
   <script>
     CMS.registerPreviewStyle("/admin/preview.css");
   </script>


### PR DESCRIPTION
Hi David, the `cms.js` bundle will be deprecated in the next major release, so better to use `netlify-cms.js` from now on.